### PR TITLE
Change pattern of importing `normalizeModelName`

### DIFF
--- a/addon/private-api.js
+++ b/addon/private-api.js
@@ -4,8 +4,10 @@
 */
 
 import Ember from 'ember';
-import normalizeModelName from "ember-data/-private/system/normalize-model-name";
+import DS from 'ember-data';
 import { singularize } from 'ember-inflector';
+
+const { normalizeModelName } = DS;
 
 export function lookupIdentityKey(store, type, id) {
   return store._internalModelForId(singularize(normalizeModelName(type)), id);


### PR DESCRIPTION
This change prevents this addon from breaking in consuming applications that
are using Ember Data >= 2.14.0, where `ember-data/-private/system/normalize-model-name`
is no longer available. It appears as though it can simply be [destructured from the top-level `DS` object](https://www.emberjs.com/api/ember-data/2.14/namespaces/DS/methods/normalizeModelName?anchor=normalizeModelName) instead.

([This part of an Ember Data discussion](https://github.com/emberjs/data/issues/5021#issuecomment-310510651) might also lend a bit more insight.)

@ef4 It might also be useful to update the addon to the latest Ember CLI/Ember Data, but I wanted to leave that for a separate change.