### PR TITLE
Collect metadata for records loaded via relationships

### DIFF
--- a/addon/adapter-mixin.js
+++ b/addon/adapter-mixin.js
@@ -58,13 +58,13 @@ export default Ember.Mixin.create({
     return this._correlateMetadata(null, () => {
       return this._super(store, type, query);
     });
-  }
+  },
 
   findHasMany(store, snapshot, url, relationship) {
     return this._correlateMetadata(null, () => {
       return this._super(store, snapshot, url, relationship);
     });
-  }
+  },
   
   findBelongsTo(store, snapshot, url, relationship) {
     return this._correlateMetadata(null, () => {


### PR DESCRIPTION
When accessing child models via the parent's DS.belongsTo() or DS.hasMany() attributes metadata was not getting collected.